### PR TITLE
enable setting of $service_start_yes & $deamon_options with defaults

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,13 @@
 #   Maximum size in bytes that beanstalkd allows for a job. Defaults to
 #   '65535'.
 #
+# [*service_start_yes*]
+#   Start service at system boot. Defaults to false
+#
+# [*daemon_options*]
+#  Pass Options (e.g. listen_addr) to service. Defaults to false
+#
+#
 # === Examples
 #
 #  class { 'beanstalkd':
@@ -59,15 +66,18 @@
 # Copyright 2015 Jeremy Bowers, unless otherwise noted.
 #
 class beanstalkd (
-  $listen_addr      = $beanstalkd::params::listen_addr,
-  $listen_port      = $beanstalkd::params::listen_port,
-  $enable_binlog    = $beanstalkd::params::enable_binlog,
-  $binlog_directory = $beanstalkd::params::binlog_directory,
-  $package_ensure   = $beanstalkd::params::package_ensure,
-  $service_ensure   = $beanstalkd::params::service_ensure,
-  $service_enable   = $beanstalkd::params::service_enable,
-  $user             = $beanstalkd::params::user,
-  $max_job_size     = $beanstalkd::params::max_job_size,
+  $listen_addr        = $beanstalkd::params::listen_addr,
+  $listen_port        = $beanstalkd::params::listen_port,
+  $enable_binlog      = $beanstalkd::params::enable_binlog,
+  $binlog_directory   = $beanstalkd::params::binlog_directory,
+  $package_ensure     = $beanstalkd::params::package_ensure,
+  $service_ensure     = $beanstalkd::params::service_ensure,
+  $service_enable     = $beanstalkd::params::service_enable,
+  $user               = $beanstalkd::params::user,
+  $max_job_size       = $beanstalkd::params::max_job_size,
+  $service_start_yes  = $beanstalkd::params::service_start_yes,
+  $daemon_options     = $beanstalkd::params::daemon_options
+
 ) inherits beanstalkd::params {
 
   # Anchor this as per #8040 - this ensures that classes won't float off and

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,13 +1,15 @@
 #
 class beanstalkd::params {
 
-  $listen_addr      = '127.0.0.1'
-  $listen_port      = '11300'
-  $enable_binlog    = false
-  $package_ensure   = 'present'
-  $service_ensure   = 'running'
-  $service_enable   = true
-  $max_job_size     = '65535'
+  $listen_addr        = '127.0.0.1'
+  $listen_port        = '11300'
+  $enable_binlog      = false
+  $package_ensure     = 'present'
+  $service_ensure     = 'running'
+  $service_enable     = true
+  $max_job_size       = '65535'
+  $service_start_yes  = false
+  $daemon_options     = false
 
   case $::osfamily {
     'Debian': {
@@ -15,9 +17,6 @@ class beanstalkd::params {
       {
         $service_start_yes  = true
         $daemon_options     = true
-      } else {
-        $service_start_yes = false
-        $daemon_options    = false
       }
       $binlog_directory = '/var/lib/beanstalkd'
       $config           = '/etc/default/beanstalkd'


### PR DESCRIPTION
overwriting these params can be useful on other Debian systems rather than Ubuntu 12.04 (Wheezy in my example)