### PR TITLE
Cluster

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,6 +70,7 @@ class beanstalkd (
   $service_restart  = $beanstalkd::params::service_restart,
   $user             = $beanstalkd::params::user,
   $max_job_size     = $beanstalkd::params::max_job_size,
+  $fsync            = $beanstalkd::params::fsync,
 ) inherits beanstalkd::params {
 
   # Anchor this as per #8040 - this ensures that classes won't float off and

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,7 @@ class beanstalkd (
   $service_manage   = $beanstalkd::params::service_manage,
   $service_ensure   = $beanstalkd::params::service_ensure,
   $service_enable   = $beanstalkd::params::service_enable,
+  $service_restart  = $beanstalkd::params::service_restart,
   $user             = $beanstalkd::params::user,
   $max_job_size     = $beanstalkd::params::max_job_size,
 ) inherits beanstalkd::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,10 @@
 #   Whether the beanstalkd package is present. Defaults to 'present'. Other 
 #   values are 'latest', or a specific version.
 #
+# [*service_manage*]
+#   Whether the beanstalkd service should be managed by puppet. This allows
+#   service_ensure to be set to 'undef'.
+#
 # [*service_ensure*]
 #   Whether the beanstalkd service should be running. Defaults to 'running'.
 #   Other value is 'stopped'.
@@ -31,12 +35,19 @@
 #   Whether the beanstalkd service should be enabled at boot. Defaults to
 #   true. Other value is false.
 #
+# [*service_restart*]
+#   Gives the user the option to set service restart command to '/bin/true'
+#   if notifies should't restart the service.
+#
 # [*user*]
 #   User that the beanstalkd process runs as. Default is 'beanstalkd'.
 #
 # [*max_job_size*]
 #   Maximum size in bytes that beanstalkd allows for a job. Defaults to
 #   '65535'.
+#
+# [*fsync*]
+#   Set this for forcing fsync every n ms (0 for always). Defaults to off.
 #
 # === Examples
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,7 @@ class beanstalkd (
   $enable_binlog    = $beanstalkd::params::enable_binlog,
   $binlog_directory = $beanstalkd::params::binlog_directory,
   $package_ensure   = $beanstalkd::params::package_ensure,
+  $service_manage   = $beanstalkd::params::service_manage,
   $service_ensure   = $beanstalkd::params::service_ensure,
   $service_enable   = $beanstalkd::params::service_enable,
   $user             = $beanstalkd::params::user,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class beanstalkd::params {
     $service_ensure   = undef
   }
   $service_enable   = true
+  $service_restart  = undef
   $max_job_size     = '65535'
 
   case $::osfamily {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,12 @@ class beanstalkd::params {
   $listen_port      = '11300'
   $enable_binlog    = false
   $package_ensure   = 'present'
-  $service_ensure   = 'running'
+  $service_manage   = true
+  if ($beanstalkd::service_manage) {
+    $service_ensure   = 'running'
+  } else {
+    $service_ensure   = undef
+  }
   $service_enable   = true
   $max_job_size     = '65535'
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class beanstalkd::params {
   $service_enable   = true
   $service_restart  = undef
   $max_job_size     = '65535'
+  $fsync            = undef
 
   case $::osfamily {
     'Debian': {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,6 +12,7 @@ class beanstalkd::service inherits beanstalkd {
     enable     => $service_enable,
     hasstatus  => true,
     hasrestart => true,
+    restart    => $service_restart,
   }
 
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,8 +1,10 @@
 #
 class beanstalkd::service inherits beanstalkd {
 
-  if ! ($service_ensure in [ 'running', 'stopped' ]) {
-    fail('service_ensure parameter must be running or stopped')
+  if ($service_manage == true) {
+    if ! ($service_ensure in [ 'running', 'stopped' ]) {
+      fail('service_ensure parameter must be running or stopped')
+    }
   }
 
   service { 'beanstalkd':

--- a/templates/beanstalkd.debian.erb
+++ b/templates/beanstalkd.debian.erb
@@ -12,7 +12,7 @@ DAEMONUSER=<%= @user %>
 # for a list of the available options. Uncomment the following line for
 # persistent job storage.
 
-BEANSTALKD_EXTRA="<% if @enable_binlog -%>-b <%= @binlog_directory -%><% end %> -z $BEANSTALKD_MAX_JOB_SIZE"
+BEANSTALKD_EXTRA="<% if @enable_binlog -%>-b <%= @binlog_directory -%><% end %> -z $BEANSTALKD_MAX_JOB_SIZE <% if @fsync -%>-f<%= @fsync -%><% end %>"
 
 <%if @daemon_options -%>
 DAEMON_OPTS="-l $BEANSTALKD_LISTEN_ADDR -p $BEANSTALKD_LISTEN_PORT $BEANSTALKD_EXTRA"


### PR DESCRIPTION
Makes beanstalkd work in a clustered setup where only the master should run beanstalkd and the cluster manager manages the services.

Also addes fsync (good for clustered setup to make sure that all data is written in case of failover).
