### PR TITLE
remove interpolation from BEANSTALKD_EXTRA

### DIFF
--- a/templates/beanstalkd.debian.erb
+++ b/templates/beanstalkd.debian.erb
@@ -12,7 +12,7 @@ DAEMONUSER=<%= @user %>
 # for a list of the available options. Uncomment the following line for
 # persistent job storage.
 
-BEANSTALKD_EXTRA="<% if @enable_binlog -%>-b <%= @binlog_directory -%><% end %> -z $BEANSTALKD_MAX_JOB_SIZE"
+BEANSTALKD_EXTRA="<% if @enable_binlog -%>-b <%= @binlog_directory -%><% end %> -z <%= @max_job_size %>"
 
 <%if @daemon_options -%>
 DAEMON_OPTS="-l $BEANSTALKD_LISTEN_ADDR -p $BEANSTALKD_LISTEN_PORT $BEANSTALKD_EXTRA"


### PR DESCRIPTION
As is, beanstalkd does not run under systemd because the variable interpolation within BEANSTALKD_EXTRA does not work. 

This change explicitly duplicates the BEANSTALKD_MAX_JOB_SIZE variable within BEANSTALKD_EXTRA rather than relying on interpolation. After applying the change, systemd works like a dream and legacy systems should not be affected.